### PR TITLE
WIP: Adds pipeline to build & deploy to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to NPM
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ➡️ Checkout
+        uses: actions/checkout@v2
+
+      - name: 🛠️ Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20.11"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: 🏗️ Install dependencies and build
+        run: npm ci && npm run build
+
+      - name: 📦 Publish package to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
Initial GitHub actions scaffolding.

Not had opportunity to fully test it yet as the actual upmind-ui build is failing due to the following: 

> error TS6230: Option ‘composite’ can only be specified in ‘tsconfig.json’ file or set to ‘false’ or ‘null’ on command line.

If I disable this, I get library errors - Has this per-chance only been built as part of another project (ie. with `npm link`)?

Once that's resolved, I can test the pipeline properly and make further changes before squashing & merging.