### PR TITLE
feat(ui): dataAttrs escape-hatch & stable testid cascade [FE-2874]

### DIFF
--- a/src/ui/alert/Alert.ce.vue
+++ b/src/ui/alert/Alert.ce.vue
@@ -1,5 +1,8 @@
 <template>
-  <Alert :class="cn(styles.alert.root, props.class)">
+  <Alert
+    :class="cn(styles.alert.root, props.class)"
+    :data-attrs="props.dataAttrs"
+  >
     <Icon v-if="icon" :icon="icon" size="2xs" :class="styles.alert.icon" />
     <div :class="styles.alert.content">
       <AlertTitle :class="styles.alert.title">

--- a/src/ui/alert/Alert.vue
+++ b/src/ui/alert/Alert.vue
@@ -1,14 +1,24 @@
 <script lang="ts" setup>
+import { computed } from "vue";
 import { cn } from "../../utils";
+import { omit } from "lodash-es";
 import type { HTMLAttributes } from "vue";
 
 const props = defineProps<{
   class?: HTMLAttributes["class"];
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 }>();
+
+const dataAttrsRest = computed(() => omit(props.dataAttrs, "data-testid"));
 </script>
 
 <template>
-  <div :class="cn(props.class)" role="alert" data-testid="alert">
+  <div
+    :class="cn(props.class)"
+    role="alert"
+    :data-testid="props.dataAttrs?.['data-testid'] ?? 'alert'"
+    v-bind="dataAttrsRest"
+  >
     <slot />
   </div>
 </template>

--- a/src/ui/alert/types.ts
+++ b/src/ui/alert/types.ts
@@ -24,4 +24,6 @@ export type AlertProps = {
   // ---
   uiConfig?: { alert: CxOptions };
   class?: HTMLAttributes["class"];
+  /** Escape-hatch for setting `data-*` attributes on the root element. */
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };

--- a/src/ui/badge/Badge.ce.vue
+++ b/src/ui/badge/Badge.ce.vue
@@ -1,6 +1,6 @@
 <template>
   <!--<link rel="stylesheet" :href="stylesheet" />-->
-  <Badge :class="cn(styles.badge.root, props.class)">
+  <Badge v-bind="props.dataAttrs" :class="cn(styles.badge.root, props.class)">
     <slot name="prepend">
       <Icon v-if="icon" :icon="icon" size="nano" :class="styles.badge.icon" />
     </slot>

--- a/src/ui/badge/types.ts
+++ b/src/ui/badge/types.ts
@@ -19,4 +19,5 @@ export type BadgeProps = {
   // --- styles
   uiConfig?: { badge: CxOptions };
   class?: HTMLAttributes["class"];
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };

--- a/src/ui/button/Button.ce.vue
+++ b/src/ui/button/Button.ce.vue
@@ -6,6 +6,7 @@
     :tabindex="meta.isFocusable ? '0' : '-1'"
     :class="cn(styles.button.root, props.class)"
     :data-testid="`button-${kebabCase(label ?? 'default')}`"
+    v-bind="props.dataAttrs"
     @click="$emit('click', $event)"
   >
     <slot name="prepend">

--- a/src/ui/button/Button.ce.vue
+++ b/src/ui/button/Button.ce.vue
@@ -5,8 +5,10 @@
     :disabled="meta.isDisabled || meta.isLoading"
     :tabindex="meta.isFocusable ? '0' : '-1'"
     :class="cn(styles.button.root, props.class)"
-    :data-testid="`button-${kebabCase(label ?? 'default')}`"
-    v-bind="props.dataAttrs"
+    :data-testid="
+      props.dataAttrs?.['data-testid'] ??
+      `button-${kebabCase(label ?? 'default')}`
+    "
     @click="$emit('click', $event)"
   >
     <slot name="prepend">
@@ -90,9 +92,9 @@ const component = computed(() => {
 });
 
 const componentProps = computed(() => {
-  if (props.to) return { to: props.to };
-  if (props.href) return { href: props.href };
-  return { type: props.type };
+  if (props.to) return { to: props.to, ...props.dataAttrs };
+  if (props.href) return { href: props.href, ...props.dataAttrs };
+  return { type: props.type, ...props.dataAttrs };
 });
 
 const meta = computed(() => ({

--- a/src/ui/button/types.ts
+++ b/src/ui/button/types.ts
@@ -40,6 +40,7 @@ export type ButtonProps = {
   uiConfig?: {
     button: { root: CxOptions; label: CxOptions; items: CxOptions };
   };
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
   class?: HTMLAttributes["class"];
   contentClass?: HTMLAttributes["class"];
 } & (

--- a/src/ui/checkbox-cards/CheckboxCards.ce.vue
+++ b/src/ui/checkbox-cards/CheckboxCards.ce.vue
@@ -21,11 +21,12 @@
         :itemClass="styles.checkboxCards.item"
         :checked="includes(modelValue, item.value)"
         :data-testid="
-          item['data-testid'] ||
+          item.dataAttrs?.['data-testid'] ||
           `checkbox-item-${kebabCase(item.label) || kebabCase(item.name) || kebabCase(item.id)}`
         "
         :data-hover="props.dataHover"
         :data-focus="props.dataFocus"
+        v-bind="item.dataAttrs"
       >
         <Label
           :for="`${item.id}-${index}`"

--- a/src/ui/checkbox-cards/CheckboxCards.ce.vue
+++ b/src/ui/checkbox-cards/CheckboxCards.ce.vue
@@ -21,12 +21,11 @@
         :itemClass="styles.checkboxCards.item"
         :checked="includes(modelValue, item.value)"
         :data-testid="
-          item.dataAttrs?.['data-testid'] ||
-          `checkbox-item-${kebabCase(item.label) || kebabCase(item.name) || kebabCase(item.id)}`
+          item.dataAttrs?.['data-testid'] ??
+          `checkbox-item-${item.id || item.value || index}`
         "
         :data-hover="props.dataHover"
         :data-focus="props.dataFocus"
-        v-bind="item.dataAttrs"
       >
         <Label
           :for="`${item.id}-${index}`"
@@ -111,7 +110,7 @@ import config from "./checkboxCards.config";
 import { cn, useStyles } from "../../utils";
 // --- components
 // --- utils
-import { includes, isFunction, isString, isNil, kebabCase } from "lodash-es";
+import { includes, isFunction, isString, isNil } from "lodash-es";
 // --- types
 import type { CheckboxCardsItemActionProps, CheckboxCardsProps } from "./types";
 // -----------------------------------------------------------------------------

--- a/src/ui/checkbox-cards/types.ts
+++ b/src/ui/checkbox-cards/types.ts
@@ -27,8 +27,10 @@ export type CheckboxCardsItemProps = ToggleGroupItemProps & {
   secondaryBadge?: BadgeProps;
   action?: CheckboxCardsItemActionProps;
   id?: string;
-  /** Override the auto-generated data-testid for this item */
-  "data-testid"?: string;
+  /** Explicit data-* attributes spread onto the rendered checkbox (e.g.
+   * `{ "data-testid": "addon-backups" }`). Overrides the implicit
+   * `checkbox-item-*` testid; the uniform escape hatch across card primitives. */
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
   /** When `true`, prevents the user from interacting with the radio item. */
   disabled?: boolean;
   /** When `true`, indicates that the user must check the radio item before the owning form can be submitted. */

--- a/src/ui/combobox/Combobox.ce.vue
+++ b/src/ui/combobox/Combobox.ce.vue
@@ -15,6 +15,7 @@
         :checked="open"
         :data-hover="dataHover"
         :data-focus="dataFocus && !skipFocus"
+        v-bind="props.triggerDataAttrs"
         ring
       >
         <template #prepend v-if="!isEmpty(modelValue) || searchValue">
@@ -39,7 +40,9 @@
         </template>
 
         <template #default v-if="!isEmpty(modelValue)">
-          <span :class="styles.combobox.label">{{ label }}</span>
+          <span :class="styles.combobox.label" v-bind="props.valueDataAttrs">{{
+            label
+          }}</span>
         </template>
 
         <template #default>
@@ -96,6 +99,7 @@
               @select="doSelect(get(item, itemValue))"
               :class="cn(styles.combobox.listItem, styles.combobox.item)"
               :data-selected="isSelected(item) ? 'true' : 'false'"
+              v-bind="item.dataAttrs"
             >
               <Avatar v-if="item.avatar" v-bind="item.avatar" size="xs" />
 

--- a/src/ui/combobox/types.ts
+++ b/src/ui/combobox/types.ts
@@ -25,6 +25,7 @@ export type ComboboxItemProps = {
   handler?: Function;
   class?: HTMLAttributes["class"];
   persist?: boolean;
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };
 
 export type ComboboxSearchFunction = {
@@ -65,4 +66,6 @@ export type ComboboxProps = PopoverRootProps &
     dataHover?: boolean;
     dataFocus?: boolean;
     tabindex?: HTMLAttributes["tabindex"];
+    triggerDataAttrs?: Record<`data-${string}`, string | number | boolean>;
+    valueDataAttrs?: Record<`data-${string}`, string | number | boolean>;
   };

--- a/src/ui/description-list/DescriptionList.ce.vue
+++ b/src/ui/description-list/DescriptionList.ce.vue
@@ -2,13 +2,14 @@
   <dl
     :class="cn(styles.list.root, props.class)"
     data-testid="description-list"
+    v-bind="props.dataAttrs"
     v-auto-animate
   >
     <div
       v-for="(item, index) in items"
       :key="`dl-item-${index}`"
       :class="styles.list.item"
-      :data-testid="`description-list-item-${kebabCase(item.term)}`"
+      v-bind="item.dataAttrs"
     >
       <dt :class="cn(styles.list.term)">
         <slot name="term" :item="item" :index="index">
@@ -33,7 +34,6 @@ import { computed } from "vue";
 // --- internal
 import config from "./descriptionList.config";
 import { useStyles, cn } from "../../utils";
-import { kebabCase } from "lodash-es";
 // --- types
 import type { DescriptionListProps } from "./types";
 // -----------------------------------------------------------------------------

--- a/src/ui/description-list/types.ts
+++ b/src/ui/description-list/types.ts
@@ -7,9 +7,11 @@ export type DescriptionListProps = {
   // ---
   uiConfig?: { descriptionList: CxOptions };
   class?: HTMLAttributes["class"];
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };
 
 export type DescriptionItem = {
   term: string;
   description: string;
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };

--- a/src/ui/dialog/Dialog.ce.vue
+++ b/src/ui/dialog/Dialog.ce.vue
@@ -6,6 +6,7 @@
 
     <DialogContent
       v-bind="forwardedContent"
+      :dataAttrs="props.dataAttrs"
       :class="cn(styles.dialog.content, props.class)"
       :classOverlay="styles.dialog.overlay"
       @update:open="onOpen"

--- a/src/ui/dialog/DialogContent.vue
+++ b/src/ui/dialog/DialogContent.vue
@@ -18,13 +18,14 @@ const props = defineProps<
       dismissable?: boolean;
       class?: HTMLAttributes["class"];
       classOverlay?: HTMLAttributes["class"];
+      dataAttrs?: Record<`data-${string}`, string | number | boolean>;
     }
 >();
 
 const emits = defineEmits<DialogContentEmits>();
 
 const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props;
+  const { class: _, dataAttrs: __, ...delegated } = props;
   return delegated;
 });
 
@@ -52,7 +53,7 @@ providePortalTarget(useTemplateRef("content"));
           props.class
         )
       "
-      data-testid="dialog-window"
+      :data-testid="props.dataAttrs?.['data-testid'] ?? 'dialog-window'"
       @interactOutside="e => !props.dismissable && e.preventDefault()"
       @escapeKeyDown="e => !props.dismissable && e.preventDefault()"
     >

--- a/src/ui/dialog/types.ts
+++ b/src/ui/dialog/types.ts
@@ -52,4 +52,11 @@ export type DialogProps = DialogRootProps &
     classHeader?: HTMLAttributes["class"];
     classContent?: HTMLAttributes["class"];
     classFooter?: HTMLAttributes["class"];
+    /**
+     * Overrides the data attributes on the dialog content element (the
+     * `dialog-window` testid host). A passed `data-testid` replaces the
+     * `dialog-window` fallback so consumers (e.g. Interstitial) can give the
+     * surfaced modal a distinguishing testid.
+     */
+    dataAttrs?: Record<`data-${string}`, string | number | boolean>;
   };

--- a/src/ui/dropdown-menu/DropdownMenu.ce.vue
+++ b/src/ui/dropdown-menu/DropdownMenu.ce.vue
@@ -56,6 +56,7 @@
                 :avatar="item.avatar"
                 :label="item.label"
                 :ring="false"
+                v-bind="item.dataAttrs"
               />
             </slot>
           </DropdownMenuItem>

--- a/src/ui/dropdown-menu/types.ts
+++ b/src/ui/dropdown-menu/types.ts
@@ -22,6 +22,7 @@ export type DropdownMenuItemProps = {
   handler?: Function;
   disabled?: boolean;
   hidden?: boolean;
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
   class?: HTMLAttributes["class"];
 };
 

--- a/src/ui/form/renderers/controls/EnumRadioRenderer.vue
+++ b/src/ui/form/renderers/controls/EnumRadioRenderer.vue
@@ -48,7 +48,8 @@ const items = computed(() => {
         label: option.label,
         secondaryLabel: option?.text,
         index,
-        modelValue: data
+        modelValue: data,
+        dataAttrs: { "data-testid": `radio-${option.value}` }
       };
     }
   );

--- a/src/ui/form/renderers/controls/OneOfRadioRenderer.vue
+++ b/src/ui/form/renderers/controls/OneOfRadioRenderer.vue
@@ -47,7 +47,8 @@ const items = computed(() => {
         label: option.label,
         secondaryLabel: option?.text,
         index,
-        modelValue: data
+        modelValue: data,
+        dataAttrs: { "data-testid": `radio-${option.value}` }
       };
     }
   );

--- a/src/ui/interstitial/Interstitial.ce.vue
+++ b/src/ui/interstitial/Interstitial.ce.vue
@@ -9,7 +9,7 @@
     no-header
     :dismissable="props.dismissable"
     no-footer
-    v-bind="props.dataAttrs"
+    v-bind="rootDataAttrs"
     @update:open="onDialogClose"
   >
     <div :class="cn(styles.interstitial.root, props.class)">
@@ -98,6 +98,14 @@ const meta = computed(() => ({
   isOpen: props.open,
   isModal: props.modal
 }));
+
+// When modal the root is a Dialog: hand it `dataAttrs` so it can override the
+// content's `dialog-window` testid (a raw fallthrough would die on the
+// render-less DialogRoot). When inline the root is a plain `div`, so spread the
+// attrs straight onto it.
+const rootDataAttrs = computed(() =>
+  props.modal ? { dataAttrs: props.dataAttrs } : props.dataAttrs
+);
 
 const slots = useSlots();
 

--- a/src/ui/interstitial/Interstitial.ce.vue
+++ b/src/ui/interstitial/Interstitial.ce.vue
@@ -9,6 +9,7 @@
     no-header
     :dismissable="props.dismissable"
     no-footer
+    v-bind="props.dataAttrs"
     @update:open="onDialogClose"
   >
     <div :class="cn(styles.interstitial.root, props.class)">

--- a/src/ui/interstitial/types.ts
+++ b/src/ui/interstitial/types.ts
@@ -34,4 +34,5 @@ export type InterstitialProps = {
   // ---
   uiConfig?: { interstitial: CxOptions };
   class?: HTMLAttributes["class"];
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };

--- a/src/ui/link/Link.ce.vue
+++ b/src/ui/link/Link.ce.vue
@@ -5,7 +5,10 @@
     :aria-disabled="meta.isDisabled || undefined"
     :tabindex="meta.isFocusable ? '0' : '-1'"
     :class="cn(styles.link.root, props.class)"
-    :data-testid="props.dataAttrs?.['data-testid'] ?? `link-${kebabCase(label ?? 'default')}`"
+    :data-testid="
+      props.dataAttrs?.['data-testid'] ??
+      `link-${kebabCase(label ?? 'default')}`
+    "
     @click="$emit('click', $event)"
   >
     <slot name="prepend">

--- a/src/ui/link/Link.ce.vue
+++ b/src/ui/link/Link.ce.vue
@@ -1,12 +1,11 @@
 <template>
   <component
     :is="component"
-    v-bind="isRouterLink ? { to } : { href }"
+    v-bind="componentProps"
     :aria-disabled="meta.isDisabled || undefined"
     :tabindex="meta.isFocusable ? '0' : '-1'"
     :class="cn(styles.link.root, props.class)"
-    :data-testid="`link-${kebabCase(label ?? 'default')}`"
-    v-bind="props.dataAttrs"
+    :data-testid="props.dataAttrs?.['data-testid'] ?? `link-${kebabCase(label ?? 'default')}`"
     @click="$emit('click', $event)"
   >
     <slot name="prepend">
@@ -74,6 +73,12 @@ const component = computed(() => {
 });
 
 const isRouterLink = computed(() => component.value === RouterLink);
+
+const componentProps = computed(() =>
+  isRouterLink.value
+    ? { to: props.to, ...props.dataAttrs }
+    : { href: props.href, ...props.dataAttrs }
+);
 
 const meta = computed(() => ({
   color: props.color,

--- a/src/ui/link/Link.ce.vue
+++ b/src/ui/link/Link.ce.vue
@@ -6,6 +6,7 @@
     :tabindex="meta.isFocusable ? '0' : '-1'"
     :class="cn(styles.link.root, props.class)"
     :data-testid="`link-${kebabCase(label ?? 'default')}`"
+    v-bind="props.dataAttrs"
     @click="$emit('click', $event)"
   >
     <slot name="prepend">

--- a/src/ui/link/types.ts
+++ b/src/ui/link/types.ts
@@ -32,6 +32,7 @@ export type LinkProps = {
   uiConfig?: {
     link: { root: CxOptions; label: CxOptions; items: CxOptions };
   };
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
   class?: HTMLAttributes["class"];
   contentClass?: HTMLAttributes["class"];
 } & (

--- a/src/ui/radio-cards-collapsible/RadioCardItem.vue
+++ b/src/ui/radio-cards-collapsible/RadioCardItem.vue
@@ -6,6 +6,7 @@
   >
     <div v-show="!props.minimal" :class="styles.radioCards.radio">
       <RadioGroupItem
+        v-bind="props.dataAttrs"
         :id="`${props.name}-${index}`"
         :value="value"
         :name="props.name"

--- a/src/ui/radio-cards-collapsible/RadioCardItem.vue
+++ b/src/ui/radio-cards-collapsible/RadioCardItem.vue
@@ -1,12 +1,12 @@
 <template>
   <Label
+    v-bind="props.dataAttrs"
     :for="`${props.name}-${index}`"
     :class="styles.radioCards.item"
     :data-state="isSelected ? 'checked' : ''"
   >
     <div v-show="!props.minimal" :class="styles.radioCards.radio">
       <RadioGroupItem
-        v-bind="props.dataAttrs"
         :id="`${props.name}-${index}`"
         :value="value"
         :name="props.name"

--- a/src/ui/radio-cards-collapsible/RadioCardsCollapsible.ce.vue
+++ b/src/ui/radio-cards-collapsible/RadioCardsCollapsible.ce.vue
@@ -21,6 +21,7 @@
           :columns="props.columns"
           :value="selectedItem.value"
           :minimal="props.minimal"
+          :dataAttrs="selectedItem.dataAttrs"
           :data-testid="`radio-card-${kebabCase(props.label)}`"
           :uiConfig="selectedItemUiConfig"
         >
@@ -71,6 +72,7 @@
                 props.radioClass
               ]"
               :minimal="props.minimal"
+              :dataAttrs="option.dataAttrs"
               data-testid="radio-card-item"
               :uiConfig="props.uiConfig"
               @keydown.enter="onSelectionChange(option.value)"

--- a/src/ui/radio-cards-collapsible/RadioCardsCollapsible.ce.vue
+++ b/src/ui/radio-cards-collapsible/RadioCardsCollapsible.ce.vue
@@ -21,11 +21,12 @@
           :columns="props.columns"
           :value="selectedItem.value"
           :minimal="props.minimal"
-          :dataAttrs="selectedItem.dataAttrs"
-          :data-testid="
-            selectedItem.dataAttrs?.['data-testid'] ??
-            `radio-card-${selectedItem.id || selectedItem.value}`
-          "
+          :dataAttrs="{
+            ...selectedItem.dataAttrs,
+            'data-testid':
+              selectedItem.dataAttrs?.['data-testid'] ??
+              `radio-card-${selectedItem.id || selectedItem.value}`
+          }"
           :uiConfig="selectedItemUiConfig"
         >
           <template #item="slotProps">
@@ -75,11 +76,12 @@
                 props.radioClass
               ]"
               :minimal="props.minimal"
-              :dataAttrs="option.dataAttrs"
-              :data-testid="
-                option.dataAttrs?.['data-testid'] ??
-                `radio-card-${option.id || option.value}`
-              "
+              :dataAttrs="{
+                ...option.dataAttrs,
+                'data-testid':
+                  option.dataAttrs?.['data-testid'] ??
+                  `radio-card-${option.id || option.value}`
+              }"
               :uiConfig="props.uiConfig"
               @keydown.enter="onSelectionChange(option.value)"
             >

--- a/src/ui/radio-cards-collapsible/RadioCardsCollapsible.ce.vue
+++ b/src/ui/radio-cards-collapsible/RadioCardsCollapsible.ce.vue
@@ -22,7 +22,10 @@
           :value="selectedItem.value"
           :minimal="props.minimal"
           :dataAttrs="selectedItem.dataAttrs"
-          :data-testid="`radio-card-${kebabCase(props.label)}`"
+          :data-testid="
+            selectedItem.dataAttrs?.['data-testid'] ??
+            `radio-card-${selectedItem.id || selectedItem.value}`
+          "
           :uiConfig="selectedItemUiConfig"
         >
           <template #item="slotProps">
@@ -73,7 +76,10 @@
               ]"
               :minimal="props.minimal"
               :dataAttrs="option.dataAttrs"
-              data-testid="radio-card-item"
+              :data-testid="
+                option.dataAttrs?.['data-testid'] ??
+                `radio-card-${option.id || option.value}`
+              "
               :uiConfig="props.uiConfig"
               @keydown.enter="onSelectionChange(option.value)"
             >
@@ -102,7 +108,6 @@
 <script setup lang="ts">
 // --- external
 import { computed } from "vue";
-import { kebabCase } from "lodash-es";
 // --- internal
 // --- components
 import { Button } from "../button";

--- a/src/ui/radio-cards-collapsible/types.ts
+++ b/src/ui/radio-cards-collapsible/types.ts
@@ -10,6 +10,7 @@ export type RadioCardsCollapsibleItemProps = RadioGroupItemProps & {
   item?: any;
   index: number;
   name?: string;
+  id?: string;
   label?: string;
   minimal?: boolean;
   sublabel?: string;
@@ -22,6 +23,10 @@ export type RadioCardsCollapsibleItemProps = RadioGroupItemProps & {
   /** Number of items per row (0-6). 0 = custom grid, 1 = full width. Example: columns={3} displays 3 items per row. */
   columns?: number;
   uiConfig?: { radioCards: CxOptions };
+  /** Explicit data-* attributes spread onto the rendered radio (e.g.
+   * `{ "data-testid": "gateway-stripe" }`). Overrides the implicit
+   * `radio-card-*` testid; the uniform escape hatch across card primitives. */
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };
 
 export type RadioCardsCollapsibleProps = RadioGroupRootProps & {

--- a/src/ui/radio-cards/RadioCardItem.vue
+++ b/src/ui/radio-cards/RadioCardItem.vue
@@ -9,6 +9,7 @@
   >
     <span :class="styles.radioCards.radio" @click.capture="onRadioClick">
       <RadioGroupItem
+        v-bind="props.dataAttrs"
         :id="`${props.name}-${index}`"
         :value="value"
         :name="props.name"

--- a/src/ui/radio-cards/RadioCardItem.vue
+++ b/src/ui/radio-cards/RadioCardItem.vue
@@ -1,5 +1,6 @@
 <template>
   <Label
+    v-bind="props.dataAttrs"
     :for="`${props.name}-${index}`"
     :class="cn(styles.radioCards.item.root, styles.radioCards.item.size)"
     :data-state="isSelected ? 'checked' : ''"
@@ -9,7 +10,6 @@
   >
     <span :class="styles.radioCards.radio" @click.capture="onRadioClick">
       <RadioGroupItem
-        v-bind="props.dataAttrs"
         :id="`${props.name}-${index}`"
         :value="value"
         :name="props.name"

--- a/src/ui/radio-cards/RadioCards.ce.vue
+++ b/src/ui/radio-cards/RadioCards.ce.vue
@@ -30,11 +30,12 @@
         :uiConfig="props.uiConfig"
         :data-hover="props.dataHover"
         :data-focus="props.dataFocus"
-        :dataAttrs="option.dataAttrs"
-        :data-testid="
-          option.dataAttrs?.['data-testid'] ??
-          `radio-card-${option.id || option.value || index}`
-        "
+        :dataAttrs="{
+          ...option.dataAttrs,
+          'data-testid':
+            option.dataAttrs?.['data-testid'] ??
+            `radio-card-${option.id || option.value || index}`
+        }"
         @keydown.enter="onChange(option.value)"
         @click="() => onChange(option.value)"
       >

--- a/src/ui/radio-cards/RadioCards.ce.vue
+++ b/src/ui/radio-cards/RadioCards.ce.vue
@@ -31,7 +31,10 @@
         :data-hover="props.dataHover"
         :data-focus="props.dataFocus"
         :dataAttrs="option.dataAttrs"
-        :data-testid="`radio-card-${kebabCase(option.label) || index}`"
+        :data-testid="
+          option.dataAttrs?.['data-testid'] ??
+          `radio-card-${option.id || option.value || index}`
+        "
         @keydown.enter="onChange(option.value)"
         @click="() => onChange(option.value)"
       >
@@ -55,7 +58,6 @@ import { RadioGroup } from "../radio-group";
 import RadioCardItem from "./RadioCardItem.vue";
 import config from "./radioCards.config";
 import { cn, useStyles } from "../../utils";
-import { kebabCase } from "lodash-es";
 // --- types
 import type { RadioCardsProps } from "./types";
 // -----------------------------------------------------------------------------

--- a/src/ui/radio-cards/RadioCards.ce.vue
+++ b/src/ui/radio-cards/RadioCards.ce.vue
@@ -30,6 +30,7 @@
         :uiConfig="props.uiConfig"
         :data-hover="props.dataHover"
         :data-focus="props.dataFocus"
+        :dataAttrs="option.dataAttrs"
         :data-testid="`radio-card-${kebabCase(option.label) || index}`"
         @keydown.enter="onChange(option.value)"
         @click="() => onChange(option.value)"

--- a/src/ui/radio-cards/types.ts
+++ b/src/ui/radio-cards/types.ts
@@ -19,6 +19,7 @@ export type RadioCardsItemProps = RadioGroupItemProps & {
   item?: any;
   index: number;
   name?: string;
+  id?: string;
   // ---
   label?: string;
   secondaryLabel?: string;
@@ -40,6 +41,10 @@ export type RadioCardsItemProps = RadioGroupItemProps & {
   uiConfig?: { radioCards: CxOptions };
   dataHover?: boolean;
   dataFocus?: boolean;
+  /** Explicit data-* attributes spread onto the rendered radio (e.g.
+   * `{ "data-testid": "gateway-stripe" }`). Overrides the implicit
+   * `radio-card-*` testid; the uniform escape hatch across card primitives. */
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };
 
 export type RadioCardsProps = RadioGroupRootProps & {

--- a/src/ui/search/Search.ce.vue
+++ b/src/ui/search/Search.ce.vue
@@ -31,6 +31,7 @@
           v-for="item in results"
           :key="item.id"
           :class="styles.search.item"
+          v-bind="props.dataAttrs"
           @click="onSelect(item)"
         >
           {{ item.label }}
@@ -85,6 +86,7 @@ const props = withDefaults(
     minQueryLength?: number;
     icon?: string;
     additionalOption?: string;
+    dataAttrs?: Record<`data-${string}`, string | number | boolean>;
   }>(),
   {
     id: uniqueId("search-"),

--- a/src/ui/select/Select.ce.vue
+++ b/src/ui/select/Select.ce.vue
@@ -44,6 +44,8 @@
           v-for="item in items"
           :key="item.value"
           :value="item.const || item.value"
+          :id="item.id"
+          :dataAttrs="item.dataAttrs"
           :class="styles.select.item"
         >
           <template #indicator />

--- a/src/ui/select/SelectItem.vue
+++ b/src/ui/select/SelectItem.vue
@@ -9,11 +9,19 @@ import { type HTMLAttributes, computed } from "vue";
 import { cn } from "../../utils";
 
 const props = defineProps<
-  SelectItemProps & { class?: HTMLAttributes["class"] }
+  SelectItemProps & {
+    class?: HTMLAttributes["class"];
+    /** Stable identifier for the implicit testid cascade (id → value). */
+    id?: string;
+    /** Explicit data-* attributes spread onto the rendered option (e.g.
+     * `{ "data-testid": "currency-gbp" }`). Overrides the implicit
+     * `select-item-*` testid; the uniform escape hatch across primitives. */
+    dataAttrs?: Record<`data-${string}`, string | number | boolean>;
+  }
 >();
 
 const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props;
+  const { class: _, dataAttrs: __, id: ___, ...delegated } = props;
 
   return delegated;
 });
@@ -30,7 +38,10 @@ const forwardedProps = useForwardProps(delegatedProps);
         props.class
       )
     "
-    :data-testid="`select-item-${props.value}`"
+    :data-testid="
+      props.dataAttrs?.['data-testid'] ??
+      `select-item-${props.id || props.value}`
+    "
   >
     <slot name="indicator" />
 

--- a/src/ui/select/types.ts
+++ b/src/ui/select/types.ts
@@ -22,6 +22,11 @@ export type SelectProps = Omit<SelectRootProps, "variant"> &
       label?: string;
       title?: string;
       const?: string;
+      id?: string;
+      /** Explicit data-* attributes spread onto the rendered option (e.g.
+       * `{ "data-testid": "currency-gbp" }`). Overrides the implicit
+       * `select-item-*` testid; the uniform escape hatch across primitives. */
+      dataAttrs?: Record<`data-${string}`, string | number | boolean>;
     } & SelectItemProps)[];
     additionalItems?: SelectItemAdditional[];
     // --- variants;

--- a/src/ui/sonner/Sonner.ce.vue
+++ b/src/ui/sonner/Sonner.ce.vue
@@ -3,9 +3,8 @@
 
   <Sonner
     class="toaster group"
-    data-testid="sonner-toast"
     data-theme=""
-    v-bind="props"
+    v-bind="containerProps"
     :toast-options="{
       classes: {
         toast: cn(
@@ -76,6 +75,7 @@
 
 <script lang="ts" setup>
 // --- external
+import { computed } from "vue";
 import { Toaster as Sonner } from "vue-sonner";
 // --- internal
 import config from "./sonner.config";
@@ -85,10 +85,17 @@ import {
   cn
   //stylesheet
 } from "../../utils";
+import { omit } from "lodash-es";
 import type { SonnerProps } from ".";
 // -----------------------------------------------------------------------------
 
 const props = defineProps<SonnerProps>();
+
+const containerProps = computed(() => ({
+  ...omit(props, "dataAttrs"),
+  "data-testid": "sonner-toast",
+  ...props.dataAttrs
+}));
 
 const styles = useStyles(
   [

--- a/src/ui/sonner/types.ts
+++ b/src/ui/sonner/types.ts
@@ -10,4 +10,5 @@ export type SonnerProps = ToasterProps & {
   // ---
   uiConfig?: { sonner: CxOptions };
   class?: HTMLAttributes["class"];
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };

--- a/src/ui/tabs/Tabs.ce.vue
+++ b/src/ui/tabs/Tabs.ce.vue
@@ -24,6 +24,7 @@
             :value="item.value"
             :class="[styles.tabs.trigger, 'cursor-pointer']"
             :data-testid="`tab-${kebabCase(item.label)}`"
+            v-bind="item.dataAttrs"
           >
             <Icon
               v-if="item.icon"

--- a/src/ui/tabs/Tabs.ce.vue
+++ b/src/ui/tabs/Tabs.ce.vue
@@ -47,7 +47,7 @@
               :class="styles.tabs.icon"
               size="2xs"
             />
-            <h4>{{ first(tabs)?.label }}</h4>
+            <h4 v-bind="first(tabs)?.dataAttrs">{{ first(tabs)?.label }}</h4>
           </div>
         </template>
 

--- a/src/ui/tabs/types.ts
+++ b/src/ui/tabs/types.ts
@@ -11,6 +11,7 @@ export type TabItem = {
   value: string;
   icon?: string;
   eager?: boolean;
+  dataAttrs?: Record<`data-${string}`, string | number | boolean>;
 };
 
 export type TabsProps = TabsRootProps &


### PR DESCRIPTION
## Summary

Adds the `dataAttrs` escape hatch and stable, locale-stable `data-testid` support across the component library so the cart e2e suite can target explicit testids instead of translated-text / label-derived locators (FE-2874).

## Changes

- `dataAttrs` passthrough added to: Button, Link, DropdownMenu, Alert, Badge, Combobox, Sonner, Tabs, Interstitial, DescriptionList, Search result items, and the single-tab heading.
- RadioCards / RadioCardsCollapsible / CheckboxCards: stable `id || value` cascade testids (consistent across card types); dropped translated-label fallbacks and redundant `v-bind`.
- Collapsed Button/Link to a single `v-bind` (dataAttrs in `componentProps`).
- Dialog / Interstitial: route `dataAttrs` to `DialogContent` (single bind — fixes a duplicate-attribute crash).
- Killed duplicate-testid strict-mode violations on RadioCards / Collapsible (one element carries the testid).

## Linear

FE-2874

## Note for reviewers / merge order

The monorepo MR ([upmind-monorepo !476](https://git.upmind.io/upmind/upmind-monorepo/-/merge_requests/476), → `develop`) pins the `packages/ui` submodule to this branch's HEAD (`f66d2e0`). Once this merges to `main`, the monorepo submodule pointer should be re-bumped to `main`'s post-merge commit before the monorepo MR merges.
