### PR TITLE
chore(security): gitignore .env files and add secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,42 @@
+name: 🔒 Secret Scan
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dotenv-guard:
+    name: 🚫 No committed .env files
+    runs-on: ubuntu-latest
+    steps:
+      - name: ➡️ Checkout
+        uses: actions/checkout@v4
+
+      - name: 🔍 Fail if any .env file is tracked
+        run: |
+          matches="$(git ls-files | grep -iE '(^|/)\.env($|\.)' | grep -viE '\.example$' || true)"
+          if [ -n "$matches" ]; then
+            echo "::error::Committed .env file(s) detected — remove them and use *.example templates:"
+            echo "$matches"
+            exit 1
+          fi
+          echo "✅ No committed .env files."
+
+  trufflehog:
+    name: 🔎 TruffleHog
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: ➡️ Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so commit ranges can be diffed
+
+      - name: 🔎 Scan for secrets
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unknown

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,13 @@ dist-ssr
 coverage
 *.local
 
+# Environment files — NEVER commit real env files (they leak secrets into git
+# history). Use committed *.example templates for shared, non-secret defaults.
+.env
+.env.*
+!.env.example
+!.env.*.example
+
 /cypress/videos/
 /cypress/screenshots/
 


### PR DESCRIPTION
- Ignore `.env.*` (allow `*.example` templates) so env files can never be committed
- Add secret scanning to pipeline